### PR TITLE
FreeBSD support: (fix) correct autogen header to use env bash

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Run this to generate all the initial makefiles, etc.
 
 srcdir=`dirname $0`


### PR DESCRIPTION
Hi,

Please look at this simple pull request. It fixes autogen file to resolve path to bash correctly on non-linux systems. 
Please feel free to ask questions.

Best regards.