### PR TITLE
Enhance download thread: avoid crash on exceptions and support HTTPS requests

### DIFF
--- a/birdieapp/utils/download.py
+++ b/birdieapp/utils/download.py
@@ -97,7 +97,7 @@ class Download(threading.Thread):
         file_normal = self.destfolder + os.path.basename(url)
         file_tmp = file_normal + '.png'
         
-        im = Image.open()
+        im = Image.open(file_bigger)
         im = add_corners(im, 10)
         im.save(file_tmp)
         try:
@@ -110,7 +110,7 @@ class Download(threading.Thread):
         try:
             self.download_url(url)
         except Exception, e:
-            print "Error: %s" % e
+            traceback.print_exc()
 
     def add(self, obj):
         """Enqueue a new object - a dict with 'url',

--- a/birdieapp/utils/download.py
+++ b/birdieapp/utils/download.py
@@ -93,7 +93,7 @@ class Download(threading.Thread):
             im = im.resize((48,48), Image.ANTIALIAS)
             return im
 
-        file_bigger = self.destfolder + os.path.basename(url).replace('_normal.', '_bigger.');
+        file_bigger = self.destfolder + os.path.basename(url).replace('_normal.', '_bigger.')
         file_normal = self.destfolder + os.path.basename(url)
         file_tmp = file_normal + '.png'
         
@@ -109,8 +109,9 @@ class Download(threading.Thread):
     def fetch_content(self, url, content_type):
         try:
             self.download_url(url)
-        except Exception, e:
-            traceback.print_exc()
+        except Exception:
+            print "Can't fetch url: %s" % url
+            raise
 
     def add(self, obj):
         """Enqueue a new object - a dict with 'url',

--- a/birdieapp/utils/download.py
+++ b/birdieapp/utils/download.py
@@ -16,9 +16,9 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import urllib
 import threading
 import traceback
+import requests
 from PIL import Image, ImageDraw
 from Queue import Queue
 from gi.repository import GLib
@@ -122,7 +122,13 @@ class Download(threading.Thread):
     def download_url(self, url):
         name = url.split('/')[-1]
         dest = os.path.join(self.destfolder, name)
-        urllib.urlretrieve(url, dest)
+        #urllib.urlretrieve(url, dest)
+        r = requests.get(url, stream=True)
+        with open(dest, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=1024): 
+                if chunk: # filter out keep-alive new chunks
+                    f.write(chunk)
+                    f.flush()
 
     def update_avatar(self, basefile, box):
         """update avatar in tweetbox for timelines"""

--- a/birdieapp/utils/download.py
+++ b/birdieapp/utils/download.py
@@ -41,55 +41,75 @@ class Download(threading.Thread):
     def run(self):
         while True:
             obj = self.queue.get()
-
-            if not os.path.exists(self.destfolder
-                                  + os.path.basename(obj['url'])):
-                try:
-                    self.download_url(obj['url'].replace('_normal.', '_bigger.'))
-                except Exception, e:
-                    print "Error: %s" % e
+            try:
+                self.process_task(obj);
+            except Exception, e:
+                print "Exc, %s", e
+            finally:
                 self.queue.task_done()
 
-                if obj['type'] != 'media' and obj['type'] != 'youtube':
-                    def add_corners(im, rad):
-                        circle = Image.new('L', (rad * 2, rad * 2), 0)
-                        draw = ImageDraw.Draw(circle)
-                        draw.ellipse((0, 0, rad * 2, rad * 2), fill=255)
-                        alpha = Image.new('L', im.size, 255)
-                        w, h = im.size
-                        alpha.paste(circle.crop((0, 0, rad, rad)), (0, 0))
-                        alpha.paste(circle.crop((0, rad, rad, rad * 2)), (0, h - rad))
-                        alpha.paste(circle.crop((rad, 0, rad * 2, rad)), (w - rad, 0))
-                        alpha.paste(circle.crop((rad, rad, rad * 2, rad * 2)), (w - rad, h - rad))
-                        im.putalpha(alpha)
-                        im = im.resize((48,48), Image.ANTIALIAS)
-                        return im
+    def process_task(self, obj):
+        url = obj['url']
+        url_bigger = url.replace('_normal.', '_bigger.')
+        content_type = obj['type']
+        
+        if not os.path.exists(self.destfolder
+                              + os.path.basename(url)):
+            self.fetch_content(url_bigger, content_type);
 
-                    im = Image.open(self.destfolder + os.path.basename(obj['url']).replace('_normal.', '_bigger.'))
-                    im = add_corners(im, 10)
-                    im.save(self.destfolder + os.path.basename(obj['url']) + '.png')   
-                    try:
-                        os.remove(self.destfolder + os.path.basename(obj['url']).replace('_normal.', '_bigger.'))
-                        os.rename(self.destfolder + os.path.basename(obj['url']) + '.png', self.destfolder + os.path.basename(obj['url']))
-                    except:
-                        pass
+        if content_type != 'media' and content_type != 'youtube':
+            self.transform_image(url)
 
-            if obj['type'] == 'avatar':
-                self.update_avatar(os.path.basename(obj['url']), obj['box'])
-            elif obj['type'] == 'media':
-                self.update_media(os.path.basename(obj['url']), obj['box'])
-            elif obj['type'] == 'youtube':
-                os.rename(self.destfolder + os.path.basename(obj['url']),
-                          self.destfolder + obj['id'] + ".jpg")
-                self.update_media(obj['id'] + ".jpg", obj['box'])
-            elif obj['type'] == 'user':
-                self.update_user_avatar(
-                    os.path.basename(obj['url']), obj['box'])
-            elif obj['type'] == 'own':
-                self.update_menu_btn_avatar(
-                    os.path.basename(obj['url']), obj['box'])
-            else:
-                pass
+        if content_type == 'avatar':
+            self.update_avatar(os.path.basename(url), obj['box'])
+        elif content_type == 'media':
+            self.update_media(os.path.basename(url), obj['box'])
+        elif content_type == 'youtube':
+            os.rename(self.destfolder + os.path.basename(url),
+                      self.destfolder + obj['id'] + ".jpg")
+            self.update_media(obj['id'] + ".jpg", obj['box'])
+        elif content_type == 'user':
+            self.update_user_avatar(
+                os.path.basename(url), obj['box'])
+        elif content_type == 'own':
+            self.update_menu_btn_avatar(
+                os.path.basename(url), obj['box'])
+        else:
+            pass
+    
+    def transform_image(self,url):
+        def add_corners(im, rad):
+            circle = Image.new('L', (rad * 2, rad * 2), 0)
+            draw = ImageDraw.Draw(circle)
+            draw.ellipse((0, 0, rad * 2, rad * 2), fill=255)
+            alpha = Image.new('L', im.size, 255)
+            w, h = im.size
+            alpha.paste(circle.crop((0, 0, rad, rad)), (0, 0))
+            alpha.paste(circle.crop((0, rad, rad, rad * 2)), (0, h - rad))
+            alpha.paste(circle.crop((rad, 0, rad * 2, rad)), (w - rad, 0))
+            alpha.paste(circle.crop((rad, rad, rad * 2, rad * 2)), (w - rad, h - rad))
+            im.putalpha(alpha)
+            im = im.resize((48,48), Image.ANTIALIAS)
+            return im
+
+        file_bigger = self.destfolder + os.path.basename(url).replace('_normal.', '_bigger.');
+        file_normal = self.destfolder + os.path.basename(url)
+        file_tmp = file_normal + '.png'
+        
+        im = Image.open()
+        im = add_corners(im, 10)
+        im.save(file_tmp)
+        try:
+            os.remove(file_bigger)
+            os.rename(file_tmp, file_normal)
+        except:
+            pass
+    
+    def fetch_content(self, url, content_type):
+        try:
+            self.download_url(url)
+        except Exception, e:
+            print "Error: %s" % e
 
     def add(self, obj):
         """Enqueue a new object - a dict with 'url',

--- a/birdieapp/utils/download.py
+++ b/birdieapp/utils/download.py
@@ -18,6 +18,7 @@
 import os
 import urllib
 import threading
+import traceback
 from PIL import Image, ImageDraw
 from Queue import Queue
 from gi.repository import GLib
@@ -43,8 +44,8 @@ class Download(threading.Thread):
             obj = self.queue.get()
             try:
                 self.process_task(obj);
-            except Exception, e:
-                print "Exc, %s", e
+            except Exception:
+                traceback.print_exc()
             finally:
                 self.queue.task_done()
 

--- a/birdieapp/utils/download.py
+++ b/birdieapp/utils/download.py
@@ -56,10 +56,11 @@ class Download(threading.Thread):
         
         if not os.path.exists(self.destfolder
                               + os.path.basename(url)):
-            self.fetch_content(url_bigger, content_type);
-
-        if content_type != 'media' and content_type != 'youtube':
-            self.transform_image(url)
+            if content_type != 'media' and content_type != 'youtube':
+                self.fetch_content(url_bigger, content_type)
+                self.transform_image(url)
+            else:
+                self.fetch_content(url, content_type)
 
         if content_type == 'avatar':
             self.update_avatar(os.path.basename(url), obj['box'])


### PR DESCRIPTION
Hi, 

Please look at this pull request. I've faced issues with downloading of resources via https with unexpected stop of download thread. This PR fixes downloading of resources thanks to library requests instead of urllib and should make download thread a bit more stable in term of exception handling. 

The number of changed lines are huge due to refactoring. For me it simplifies code and improves readability.

Please feel free to ask questions.

Best regards.