### PR TITLE
Added some padding left and right to the input dialog's entry widget.

### DIFF
--- a/birdieapp/gui/dialogs.py
+++ b/birdieapp/gui/dialogs.py
@@ -83,6 +83,8 @@ def get_input(parent, message, default=''):
                           message)
     entry = Gtk.Entry()
     entry.set_text(default)
+    entry.set_margin_left(20)
+    entry.set_margin_right(20)
     entry.show()
     d.vbox.pack_end(entry, True, True, 0)
     entry.connect('activate', lambda _: d.response(Gtk.ResponseType.OK))


### PR DESCRIPTION
Hey I know this is really minor, but I think it would like nicer if the entry widget had some margin left and right in the input dialog. Especially since the authorization PIN dialog is probably one of the first things the user sees when using Birdie for the very first time.
![dialog](https://cloud.githubusercontent.com/assets/13655994/10304908/4530996c-6c1d-11e5-8b8e-771145a54b51.png)
